### PR TITLE
Add Python modules and config folder to resources

### DIFF
--- a/src-tauri/src/documents.rs
+++ b/src-tauri/src/documents.rs
@@ -6,22 +6,19 @@ pub mod documents_handler {
     use std::io::Write;
     use std::path::PathBuf;
 
-    use crate::process_call;
+    use crate::{lib, process_call};
     use process_call::handle_python_call;
 
     pub fn copy_file(file_data: Vec<u8>, file_name: &str) -> Result<String, String> {
         let file_relative_path = format!(".{}", file_name);
-    
-        let mut file = File::create(&file_relative_path)
-            .map_err(|e| e.to_string())?;
-    
-        file.write_all(&file_data)
-            .map_err(|e| e.to_string())?;
+
+        let mut file = File::create(&file_relative_path).map_err(|e| e.to_string())?;
+
+        file.write_all(&file_data).map_err(|e| e.to_string())?;
 
         let file_path = PathBuf::from(&file_relative_path);
-        let file_abs_path = std::fs::canonicalize(file_path)
-            .map_err(|e| e.to_string())?;
-        
+        let file_abs_path = std::fs::canonicalize(file_path).map_err(|e| e.to_string())?;
+
         Ok(file_abs_path.display().to_string())
     }
 
@@ -34,17 +31,19 @@ pub mod documents_handler {
                 return Err(e);
             }
         };
-        
+
         let args: Vec<&str> = vec![file_absolute_path.as_str()];
 
         handle_python_call(
-            "../src/translator/documents.py", 
-            "documents", 
-            "File", 
-            None, 
-            "load_document", 
-            Some(args), 
-            None
-        ).map_err(|e| e.to_string())
+            lib::get_documents().unwrap_or(""),
+            "documents",
+            "File",
+            None,
+            "load_document",
+            Some(args),
+            None,
+        )
+        .map_err(|e| e.to_string())
+        
     }
 }

--- a/src-tauri/src/get_api_keys.rs
+++ b/src-tauri/src/get_api_keys.rs
@@ -2,13 +2,15 @@ use serde::{Deserialize, Serialize};
 use std::fs::File;
 use std::io::BufReader;
 
+use crate::lib;
+
 #[derive(Deserialize, Serialize, Debug)]
 pub struct Item {
     pub key: String,
 }
 
 pub fn get_deepl_keys() -> Result<Vec<Item>, Box<dyn std::error::Error>> {
-    let file = File::open("../src/config_files/deepl_keys.json")?;
+    let file = File::open(lib::get_deepl_keys_path().unwrap_or(""))?;
     let reader = BufReader::new(file);
 
     let items: Vec<Item> = serde_json::from_reader(reader)?;
@@ -16,9 +18,8 @@ pub fn get_deepl_keys() -> Result<Vec<Item>, Box<dyn std::error::Error>> {
     Ok(items)
 }
 
-
 pub fn get_gpt_keys() -> Result<Vec<Item>, Box<dyn std::error::Error>> {
-    let file = File::open("../src/config_files/gpt_keys.json")?;
+    let file = File::open(lib::get_gpt_keys_path().unwrap_or(""))?;
     let reader = BufReader::new(file);
 
     let items: Vec<Item> = serde_json::from_reader(reader)?;

--- a/src-tauri/src/glossary.rs
+++ b/src-tauri/src/glossary.rs
@@ -1,17 +1,18 @@
 pub mod glossary_handler {
-    use crate::process_call;
+    use crate::{lib, process_call};
     use process_call::handle_python_call;
 
     #[tauri::command]
-    pub async fn get_glossaries (api_key: &str,) -> Result<String, String> {
+    pub async fn get_glossaries(api_key: &str) -> Result<String, String> {
         handle_python_call(
-            "../src/translator/glossary.py", 
-            "glossary", 
-            "Glossario", 
-            Some(vec![api_key]), 
-            "get_glossaries", 
-            None, 
-            None
-        ).map_err(|e| e.to_string())
+            lib::get_glossary().unwrap_or(""),
+            "glossary",
+            "Glossario",
+            Some(vec![api_key]),
+            "get_glossaries",
+            None,
+            None,
+        )
+        .map_err(|e| e.to_string())
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -8,6 +8,8 @@ static mut DOCUMENTS: Option<String> = None;
 static mut UTILS: Option<String> = None;
 static mut TRANSLATE: Option<String> = None;
 static mut GLOSSARY: Option<String> = None;
+static mut GPT_KEYS: Option<String> = None;
+static mut DEEPL_KEYS: Option<String> = None;
 
 pub fn initialize_modules(app: &App) {
     INIT.call_once(|| {
@@ -30,6 +32,16 @@ pub fn initialize_modules(app: &App) {
         unsafe {
             GLOSSARY = Some(binding.to_str().unwrap().to_string());
         }
+
+        let binding = app.path().resolve("src/config/gpt_keys.json", BaseDirectory::Resource).unwrap();
+        unsafe {
+            GPT_KEYS = Some(binding.to_str().unwrap().to_string());
+        }
+
+        let binding = app.path().resolve("src/config/deepl_keys.json", BaseDirectory::Resource).unwrap();
+        unsafe {
+            DEEPL_KEYS = Some(binding.to_str().unwrap().to_string());
+        }
     });
 }
 
@@ -47,4 +59,12 @@ pub fn get_translate() -> Option<&'static str> {
 
 pub fn get_glossary() -> Option<&'static str> {
     unsafe { GLOSSARY.as_deref() }
+}
+
+pub fn get_gpt_keys_path() -> Option<&'static str> {
+    unsafe { GPT_KEYS.as_deref() }
+}
+
+pub fn get_deepl_keys_path() -> Option<&'static str> {
+    unsafe { DEEPL_KEYS.as_deref() }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,0 +1,50 @@
+use std::sync::Once;
+
+use tauri_plugin_updater::UpdaterExt;
+use tauri::{path::BaseDirectory, App, Manager};
+
+static INIT: Once = Once::new();
+static mut DOCUMENTS: Option<String> = None;
+static mut UTILS: Option<String> = None;
+static mut TRANSLATE: Option<String> = None;
+static mut GLOSSARY: Option<String> = None;
+
+pub fn initialize_modules(app: &App) {
+    INIT.call_once(|| {
+        let binding = app.path().resolve("src/translator/documents.py", BaseDirectory::Resource).unwrap();
+        unsafe {
+            DOCUMENTS = Some(binding.to_str().unwrap().to_string());
+        }
+
+        let binding = app.path().resolve("src/translator/utils.py", BaseDirectory::Resource).unwrap();
+        unsafe {
+            UTILS = Some(binding.to_str().unwrap().to_string());
+        }
+
+        let binding = app.path().resolve("src/translator/translate.py", BaseDirectory::Resource).unwrap();
+        unsafe {
+            TRANSLATE = Some(binding.to_str().unwrap().to_string());
+        }
+
+        let binding = app.path().resolve("src/translator/glossary.py", BaseDirectory::Resource).unwrap();
+        unsafe {
+            GLOSSARY = Some(binding.to_str().unwrap().to_string());
+        }
+    });
+}
+
+pub fn get_documents() -> Option<&'static str> {
+    unsafe { DOCUMENTS.as_deref() }
+}
+
+pub fn get_utils() -> Option<&'static str> {
+    unsafe { UTILS.as_deref() }
+}
+
+pub fn get_translate() -> Option<&'static str> {
+    unsafe { TRANSLATE.as_deref() }
+}
+
+pub fn get_glossary() -> Option<&'static str> {
+    unsafe { GLOSSARY.as_deref() }
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -7,6 +7,7 @@ mod glossary;
 mod process_call;
 mod translate;
 mod utils;
+mod lib;
 
 use std::env;
 
@@ -36,7 +37,11 @@ fn get_deep_keys() -> Result<Vec<Item>, String> {
 fn main() {
     tauri::Builder::default()
         .plugin(tauri_plugin_dialog::init())
+        .plugin(tauri_plugin_updater::Builder::default().build())
         .setup(|app| {
+            let binding = app.path().resolve("src/translator/documents.py", BaseDirectory::Resource)?;
+            let doc = binding.to_str().unwrap();
+
             let binding = app.path().resolve("src/.venv", BaseDirectory::Resource)?;
             let venv_path = binding.to_str().unwrap();
 
@@ -50,6 +55,8 @@ fn main() {
             env::set_var("PATH", new_path);
             
             env::remove_var( "PYTHONHOME");
+            
+            lib::initialize_modules(&app);
 
             Ok(())
         })
@@ -66,4 +73,5 @@ fn main() {
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
+
 }

--- a/src-tauri/src/translate.rs
+++ b/src-tauri/src/translate.rs
@@ -1,22 +1,29 @@
 pub mod translate_handler {
-    use crate::{documents::documents_handler::copy_file, process_call};
+    use crate::{documents::documents_handler::copy_file, lib, process_call};
     use process_call::handle_python_call;
 
     #[tauri::command]
-    pub async fn translate_document (api_key: &str,file_data: Vec<u8>, file_name: &str, model: &str, mut args: Vec<&str>, kwargs: Option<Vec<(&str, &str)>>) -> Result<String, String> {
-        let file_abs_path = copy_file(file_data, file_name)
-        .map_err(|e| format!("Failed to copy file: {}", e))?;
-        
+    pub async fn translate_document(
+        api_key: &str,
+        file_data: Vec<u8>,
+        file_name: &str,
+        model: &str,
+        mut args: Vec<&str>,
+        kwargs: Option<Vec<(&str, &str)>>,
+    ) -> Result<String, String> {
+        let file_abs_path =
+            copy_file(file_data, file_name).map_err(|e| format!("Failed to copy file: {}", e))?;
+
         args.insert(0, &file_abs_path);
 
         handle_python_call(
-            "../src/translator/translate.py",
+            lib::get_translate().unwrap_or(""),
             "translate",
             "Translate",
             Some(vec![api_key, model]),
             "translate_document",
             Some(args),
-            kwargs
+            kwargs,
         )
         .map_err(|e| e.to_string())
     }

--- a/src-tauri/src/utils.rs
+++ b/src-tauri/src/utils.rs
@@ -1,56 +1,60 @@
 pub mod utils_handler {
-    use crate::process_call;
+    use crate::{lib, process_call};
     use process_call::handle_python_call;
 
     #[tauri::command]
-    pub async fn get_gpt_models (api_key: &str) -> Result<String, String> {
+    pub async fn get_gpt_models(api_key: &str) -> Result<String, String> {
         handle_python_call(
-            "../src/translator/utils.py", 
-            "utils", 
+            lib::get_utils().unwrap_or(""),
+            "utils",
             "GPTAccount",
-            Some(vec![api_key]), 
-            "models", 
-            None, 
-            None
-        ).map_err(|e| e.to_string())
+            Some(vec![api_key]),
+            "models",
+            None,
+            None,
+        )
+        .map_err(|e| e.to_string())
     }
 
     #[tauri::command]
-    pub async fn get_source_languages (api_key: &str) -> Result<String, String> {
+    pub async fn get_source_languages(api_key: &str) -> Result<String, String> {
         handle_python_call(
-            "../src/translator/utils.py", 
-            "utils", 
+            lib::get_utils().unwrap_or(""),
+            "utils",
             "DeeplAccount",
-            Some(vec![api_key]), 
-            "get_languages", 
-            Some(vec!["source"]), 
-            None
-        ).map_err(|e| e.to_string())
+            Some(vec![api_key]),
+            "get_languages",
+            Some(vec!["source"]),
+            None,
+        )
+        .map_err(|e| e.to_string())
     }
 
     #[tauri::command]
-    pub async fn get_target_languages (api_key: &str) -> Result<String, String> {
+    pub async fn get_target_languages(api_key: &str) -> Result<String, String> {
         handle_python_call(
-            "../src/translator/utils.py", 
-            "utils", 
+            lib::get_utils().unwrap_or(""),
+            "utils",
             "DeeplAccount",
-            Some(vec![api_key]), 
-            "get_languages", 
-            Some(vec!["target"]), 
-            None
-        ).map_err(|e| e.to_string())
+            Some(vec![api_key]),
+            "get_languages",
+            Some(vec!["target"]),
+            None,
+        )
+        .map_err(|e| e.to_string())
     }
 
     #[tauri::command]
-    pub async fn check_usage (api_key: &str) -> Result<String, String> {
+    pub async fn check_usage(api_key: &str) -> Result<String, String> {
         handle_python_call(
-            "../src/translator/utils.py", 
-            "utils", 
+            lib::get_utils().unwrap_or(""),
+            "utils",
             "DeeplAccount",
-            Some(vec![api_key]), 
-            "check_usage", 
-            None, 
-            None
-        ).map_err(|e| e.to_string())
+            Some(vec![api_key]),
+            "check_usage",
+            None,
+            None,
+        )
+        .map_err(|e| e.to_string())
     }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -14,7 +14,8 @@
     ],
     "createUpdaterArtifacts": true,
     "resources": {
-      "../.venv": "src/.venv"
+      "../.venv": "src/.venv",
+      "../src/translator": "src/translator"
     }
   },
   "productName": "AI-translator",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -15,7 +15,8 @@
     "createUpdaterArtifacts": true,
     "resources": {
       "../.venv": "src/.venv",
-      "../src/translator": "src/translator"
+      "../src/translator": "src/translator",
+      "../src/config_files": "src/config"
     }
   },
   "productName": "AI-translator",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -12,7 +12,10 @@
       "icons/icon.icns",
       "icons/icon.ico"
     ],
-    "createUpdaterArtifacts": true
+    "createUpdaterArtifacts": true,
+    "resources": {
+      "../.venv": "src/.venv"
+    }
   },
   "productName": "AI-translator",
   "mainBinaryName": "AI-translator",


### PR DESCRIPTION
Adds both Python virtual environment and python modules in src/translator to the app BundleResources so it can be used without installing any dependency externally. Additionally, embedd config_files folder and maps it to src/config so we can parse gpt_keys.json and deepl_keys.json inside the app more easily.