### PR TITLE
Update python handler

### DIFF
--- a/.github/workflows/build-tauri.yml
+++ b/.github/workflows/build-tauri.yml
@@ -44,7 +44,14 @@ jobs:
           sudo apt-get install -y libwebkit2gtk-4.0-dev libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
         # webkitgtk 4.0 is for Tauri v1 - webkitgtk 4.1 is for Tauri v2.
         # You can remove the one that doesn't apply to your app to speed up the workflow a bit.
-
+      
+      - name: install windows python embeddable package
+        if: matrix.platform == 'windows-latest'
+        run: |
+          wget https://www.python.org/ftp/python/3.11.9/python-3.11.9-embed-amd64.zip -o ./python.zip
+          mkdir ./python
+          Tar -xf ./python.zip -C ./python
+        
       - name: install frontend dependencies
         run: yarn install # change this to npm, pnpm or bun depending on which one you use.
 

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ __pycache__/*
 
 *.dist/*
 *.so
+
+# Windows Python Embeddable package extracted folder (htps://www.python.org/ftp/python/3.11.9/python-3.11.9-embed-amd64.zip)
+python/

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2788,9 +2788,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.22.5"
+version = "0.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d922163ba1f79c04bc49073ba7b32fd5a8d3b76a87c955921234b8e77333c51"
+checksum = "e484fd2c8b4cb67ab05a318f1fd6fa8f199fcc30819f08f07d200809dba26c15"
 dependencies = [
  "cfg-if",
  "indoc",
@@ -2806,9 +2806,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.22.5"
+version = "0.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc38c5feeb496c8321091edf3d63e9a6829eab4b863b4a6a65f26f3e9cc6b179"
+checksum = "dc0e0469a84f208e20044b98965e1561028180219e35352a2afaf2b942beff3b"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -2816,9 +2816,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.22.5"
+version = "0.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94845622d88ae274d2729fcefc850e63d7a3ddff5e3ce11bd88486db9f1d357d"
+checksum = "eb1547a7f9966f6f1a0f0227564a9945fe36b90da5a93b3933fc3dc03fae372d"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -2826,9 +2826,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.22.5"
+version = "0.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e655aad15e09b94ffdb3ce3d217acf652e26bbc37697ef012f5e5e348c716e5e"
+checksum = "fdb6da8ec6fa5cedd1626c886fc8749bdcbb09424a86461eb8cdf096b7c33257"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -2838,9 +2838,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.22.5"
+version = "0.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae1e3f09eecd94618f60a455a23def79f79eba4dc561a97324bf9ac8c6df30ce"
+checksum = "38a385202ff5a92791168b1136afae5059d3ac118457bb7bc304c197c2d33e7d"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -15,7 +15,7 @@ tauri-build = { version = "2", features = [] }
 tauri = { version = "2", features = [] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-pyo3 = { version = "0.22.3"}
+pyo3 = { version = "0.23.3"}
 tauri-plugin-shell = "2"
 tauri-plugin-dialog = "2"
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -39,22 +39,6 @@ fn main() {
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_updater::Builder::default().build())
         .setup(|app| {
-            let binding = app.path().resolve("src/translator/documents.py", BaseDirectory::Resource)?;
-            let doc = binding.to_str().unwrap();
-
-            let binding = app.path().resolve("src/.venv", BaseDirectory::Resource)?;
-            let venv_path = binding.to_str().unwrap();
-
-            let binding = app.path().resolve("src/.venv/bin", BaseDirectory::Resource)?;
-            let bin_path = binding.to_str().unwrap();
-
-            let cur_path = env::var("PATH").unwrap();
-
-            let new_path = format!("{}:{}:{}", bin_path, venv_path, cur_path);
-
-            env::set_var("PATH", new_path);
-            
-            env::remove_var( "PYTHONHOME");
             
             lib::initialize_modules(&app);
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -39,8 +39,13 @@ fn main() {
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_updater::Builder::default().build())
         .setup(|app| {
+            let binding = app.path().resolve(".", BaseDirectory::Resource).unwrap();
+            let path = binding.to_str().unwrap();
+            env::set_var("PYTHONPATH", path);
             
             lib::initialize_modules(&app);
+
+            let _ = process_call::set_sys_path();
 
             Ok(())
         })

--- a/src-tauri/src/process_call.rs
+++ b/src-tauri/src/process_call.rs
@@ -1,4 +1,5 @@
 use std::fs;
+use std::ffi::CString;
 
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList, PyTuple};
@@ -9,17 +10,21 @@ pub fn call_python(file_path: &str, module: &str, class: &str, object_args: Opti
 
     let file_name = format!("{}.py",module);
     let code = fs::read_to_string(file_path).expect("Python file not found");
+    let module = module.to_string();
     
     Python::with_gil(|py| {
+        let code_cstr = CString::new(code).unwrap();
+        let file_name_cstr = CString::new(file_name).unwrap();
+        let module_cstr = CString::new(module).unwrap();
 
-        let py_module = PyModule::from_code_bound(py, &code, &file_name, module)?;
+        let py_module = PyModule::from_code(py, &code_cstr, &file_name_cstr, &module_cstr)?;
 
         let py_object = py_module.getattr(class)?;
 
         let py_class: Bound<'_, PyAny>;
 
         if let Some(object_args) = object_args{
-            let method_args = PyTuple::new_bound(py, object_args);
+            let method_args = PyTuple::new(py, object_args).unwrap();
             py_class = py_object.call1(method_args)?;
         }else{
             py_class = py_object.call0()?;
@@ -30,19 +35,19 @@ pub fn call_python(file_path: &str, module: &str, class: &str, object_args: Opti
                 py_class.call_method0(method)?
             }
             (Some(arg_list), None) => {
-                let method_args = PyTuple::new_bound(py, arg_list);
+                let method_args = PyTuple::new(py, arg_list).unwrap();
                 py_class.call_method1(method, method_args)?
             }
             (Some(arg_list), Some(kwarg_list)) => {
-                let method_args = PyTuple::new_bound(py, arg_list);
-                let method_kwargs = PyDict::new_bound(py);
+                let method_args = PyTuple::new(py, arg_list).unwrap();
+                let method_kwargs = PyDict::new(py);
                 for (key, value) in kwarg_list {
                     method_kwargs.set_item(key, value)?;
                 }
                 py_class.call_method(method, method_args, Some(&method_kwargs))?
             }
             (None, Some(kwarg_list)) => {
-                let method_kwargs = PyDict::new_bound(py);
+                let method_kwargs = PyDict::new(py);
                 for (key, value) in kwarg_list {
                     method_kwargs.set_item(key, value)?;
                 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -14,7 +14,6 @@
     ],
     "createUpdaterArtifacts": true,
     "resources": {
-      "../.venv": "src/.venv",
       "../src/translator": "src/translator",
       "../src/config_files": "src/config"
     }
@@ -28,10 +27,7 @@
       "pubkey":"dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDc1NjU5RUY4NzFCMEVFRTkKUldUcDdyQngrSjVsZGRqOG5uZkRqaTNCMWMwYmJyRHg3VWtoZ3M1OGVLVlMzUDJVWi9sUUJyaUUK",
       "endpoints": [
         "https://github.com/snootic/ai-office-translator/releases/latest/download/latest/latest.json"
-      ],
-      "windows": {
-        "installMode": "passive"
-      } 
+      ] 
     }
   },
   "app": {

--- a/src-tauri/tauri.linux.conf.json
+++ b/src-tauri/tauri.linux.conf.json
@@ -1,0 +1,8 @@
+{
+    "bundle": {
+        "resources": {
+            "../.venv/bin": ".",
+            "../.venv/lib/python3.11/site-packages": "Lib"
+        }
+    }
+}

--- a/src-tauri/tauri.macos.conf.json
+++ b/src-tauri/tauri.macos.conf.json
@@ -1,0 +1,8 @@
+{
+    "bundle": {
+        "resources": {
+            "../.venv/bin": ".",
+            "../.venv/lib/python3.11/site-packages": "Lib"
+        }
+    }
+}

--- a/src-tauri/tauri.windows.conf.json
+++ b/src-tauri/tauri.windows.conf.json
@@ -1,0 +1,16 @@
+{
+  "bundle": {
+    "resources": {
+      "../.venv/Scripts": ".",
+      "../.venv/Lib/site-packages": "Lib",
+      "../Python": "."
+    }
+  },
+  "plugins": {
+    "updater": {
+      "windows": {
+        "installMode": "passive"
+      } 
+    }
+  }
+}


### PR DESCRIPTION
This pull request updates Pyo3 to version 0.23.3 and adds a new logic to how the apps handles the python dependencies and the interpreter based on the operating system (don't know if macos works). It sets dynamically on start the sys.path variable on python to supports the new /Lib folder containing all libraries necessary, the PYTHONPATH variable and now uses the Python Embeddable package from python.org for Windows, discarding the necessity of installing python on the machine.